### PR TITLE
feat: spec-codegen tracing and compile error navigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "similar",
  "syntect",
  "tempfile",
+ "two-face",
  "walkdir",
 ]
 
@@ -907,6 +908,17 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "two-face"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b285c51f8a6ade109ed4566d33ac4fb289fb5d6cf87ed70908a5eaf65e948e34"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "syntect",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ include_dir = "0.7"
 shell-words = "1.1.1"
 similar = "2"
 syntect = "5"
+two-face = { version = "0.5", default-features = false, features = ["syntect-onig"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -334,6 +334,7 @@ mod tests {
     #[test]
     fn syntax_name_known_extensions() {
         assert_eq!(syntax_name_for_path(Path::new("App.java")), "Java");
+        assert_eq!(syntax_name_for_path(Path::new("App.kt")), "Kotlin");
         assert_eq!(syntax_name_for_path(Path::new("index.ts")), "TypeScript");
         assert_eq!(syntax_name_for_path(Path::new("main.go")), "Go");
         assert_eq!(syntax_name_for_path(Path::new("lib.py")), "Python");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,5 +1,6 @@
 pub mod browser;
 pub mod diff;
 pub mod state;
+pub mod trace;
 
 pub use state::{App, BrowserPanel, Panel, PhaseStatus, ScreenMode, StatusLevel, ViewMode};

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -13,6 +13,8 @@ use lazyoav::docker::CancelToken;
 use lazyoav::keys::Keymap;
 use lazyoav::pipeline::{PipelineEvent, ValidateReport};
 
+use super::trace::{CompileError, TraceIndex};
+
 use super::diff::DiffViewState;
 
 /// Top-level view: validator grid or generated code browser.
@@ -61,6 +63,8 @@ pub struct CodeBrowserState {
     pub highlight_engine: RefCell<HighlightEngine>,
     /// State for the generation diff toggle mode.
     pub diff_state: DiffViewState,
+    /// Bidirectional spec ↔ codegen trace index for the active generator.
+    pub trace_index: Option<TraceIndex>,
 }
 
 impl CodeBrowserState {
@@ -77,6 +81,7 @@ impl CodeBrowserState {
             content_version: 0,
             highlight_engine: RefCell::new(HighlightEngine::new()),
             diff_state: DiffViewState::new(),
+            trace_index: None,
         }
     }
 
@@ -225,6 +230,8 @@ pub struct App {
 
     /// Parsed lint errors from the report's lint log.
     pub lint_errors: Vec<LintError>,
+    /// Parsed compile errors from compile logs, keyed by `"{generator}/{scope}"`.
+    pub compile_errors: HashMap<String, Vec<CompileError>>,
     /// Parsed spec index for source mapping.
     pub spec_index: Option<SpecIndex>,
 
@@ -277,6 +284,7 @@ impl App {
             report: None,
             validating: false,
             lint_errors: Vec::new(),
+            compile_errors: HashMap::new(),
             spec_index: None,
             pipeline_rx: None,
             cancel_token: None,
@@ -357,10 +365,12 @@ impl App {
 
         if let Some(steps) = &report.phases.compile {
             for step in steps {
+                let key = format!("{}/{}", step.generator, step.scope);
+                let error_count = self.compile_errors.get(&key).map(|e| e.len()).unwrap_or(0);
                 entries.push(PhaseEntry {
                     label: format!("Compile ({}/{})", step.generator, step.scope),
                     status: PhaseStatus::from_status_str(&step.status),
-                    error_count: 0,
+                    error_count,
                 });
             }
         }
@@ -383,6 +393,70 @@ impl App {
     pub fn selected_error(&self) -> Option<&LintError> {
         let errors = self.current_errors();
         errors.get(self.error_index)
+    }
+
+    /// Compile errors for the currently selected phase, if it is a compile phase.
+    pub fn current_compile_errors(&self) -> &[CompileError] {
+        let Some(report) = &self.report else {
+            return &[];
+        };
+
+        let mut idx = self.phase_index;
+
+        if report.phases.lint.is_some() {
+            if idx == 0 {
+                return &[];
+            }
+            idx -= 1;
+        }
+
+        if let Some(steps) = &report.phases.generate {
+            if idx < steps.len() {
+                return &[];
+            }
+            idx -= steps.len();
+        }
+
+        if let Some(steps) = &report.phases.compile
+            && idx < steps.len()
+        {
+            let step = &steps[idx];
+            let key = format!("{}/{}", step.generator, step.scope);
+            if let Some(errors) = self.compile_errors.get(&key) {
+                return errors;
+            }
+        }
+
+        &[]
+    }
+
+    /// Returns the (generator, scope) for the currently selected phase if it is
+    /// a compile or generate phase.
+    pub fn selected_phase_generator(&self) -> Option<(&str, &str)> {
+        let report = self.report.as_ref()?;
+        let mut idx = self.phase_index;
+
+        if report.phases.lint.is_some() {
+            if idx == 0 {
+                return None;
+            }
+            idx -= 1;
+        }
+
+        if let Some(steps) = &report.phases.generate {
+            if idx < steps.len() {
+                return Some((&steps[idx].generator, &steps[idx].scope));
+            }
+            idx -= steps.len();
+        }
+
+        if let Some(steps) = &report.phases.compile
+            && idx < steps.len()
+        {
+            return Some((&steps[idx].generator, &steps[idx].scope));
+        }
+
+        None
     }
 
     /// Clamp phase_index and error_index to valid bounds.

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -468,7 +468,10 @@ impl App {
             self.phase_index = 0;
         }
 
-        let error_count = self.current_errors().len();
+        let error_count = self
+            .current_errors()
+            .len()
+            .max(self.current_compile_errors().len());
         if error_count > 0 {
             self.error_index = self.error_index.min(error_count - 1);
         } else {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -11,7 +11,7 @@ use lazyoav::config::Config;
 use lazyoav::custom::CustomGeneratorDef;
 use lazyoav::docker::CancelToken;
 use lazyoav::keys::Keymap;
-use lazyoav::pipeline::{PipelineEvent, ValidateReport};
+use lazyoav::pipeline::{LintResult, Phase, PipelineEvent, ValidateReport};
 
 use super::trace::{CompileError, TraceIndex};
 
@@ -242,6 +242,11 @@ pub struct App {
     /// Real-time log output from the active pipeline phase.
     pub live_log: String,
 
+    /// Live phase status during a pipeline run (before Completed arrives).
+    pub live_phases: Vec<(Phase, PhaseStatus)>,
+    /// Lint result received mid-pipeline (before the full report).
+    pub live_lint_result: Option<LintResult>,
+
     /// Path to the OpenAPI spec file, if discovered.
     pub spec_path: Option<PathBuf>,
 
@@ -289,6 +294,8 @@ impl App {
             pipeline_rx: None,
             cancel_token: None,
             live_log: String::new(),
+            live_phases: Vec::new(),
+            live_lint_result: None,
             spec_path: None,
             config: None,
             custom_defs: Vec::new(),
@@ -321,6 +328,10 @@ impl App {
 
     /// Number of phases without allocating entry labels.
     pub fn phase_count(&self) -> usize {
+        if self.report.is_none() && !self.live_phases.is_empty() {
+            return self.live_phases.len();
+        }
+
         let Some(report) = &self.report else {
             return 0;
         };
@@ -337,8 +348,29 @@ impl App {
         count
     }
 
-    /// Build the list of phase entries from the current report.
+    /// Build the list of phase entries from the current report or live data.
     pub fn phase_entries(&self) -> Vec<PhaseEntry> {
+        // During a pipeline run, build entries from live phase tracking.
+        if self.report.is_none() && !self.live_phases.is_empty() {
+            return self
+                .live_phases
+                .iter()
+                .map(|(phase, status)| {
+                    let error_count =
+                        if *status != PhaseStatus::Running && matches!(phase, Phase::Lint) {
+                            self.lint_errors.len()
+                        } else {
+                            0
+                        };
+                    PhaseEntry {
+                        label: phase_label(phase),
+                        status: *status,
+                        error_count,
+                    }
+                })
+                .collect();
+        }
+
         let Some(report) = &self.report else {
             return Vec::new();
         };
@@ -380,6 +412,11 @@ impl App {
 
     /// Errors for the currently selected phase (lint only for now).
     pub fn current_errors(&self) -> &[LintError] {
+        // During validation: lint errors are available as soon as lint completes.
+        if self.report.is_none() && self.live_lint_result.is_some() && self.phase_index == 0 {
+            return &self.lint_errors;
+        }
+
         if let Some(report) = &self.report
             && report.phases.lint.is_some()
             && self.phase_index == 0
@@ -481,6 +518,16 @@ impl App {
 
     /// Raw log text for the currently selected phase.
     pub fn current_phase_log(&self) -> &str {
+        // During validation: return the lint log if lint is done and selected.
+        if self.report.is_none() {
+            if let Some(lint) = &self.live_lint_result
+                && self.phase_index == 0
+            {
+                return &lint.log;
+            }
+            return "";
+        }
+
         let Some(report) = &self.report else {
             return "";
         };
@@ -513,6 +560,15 @@ impl App {
         }
 
         ""
+    }
+}
+
+/// Human-readable label for a pipeline `Phase`.
+fn phase_label(phase: &Phase) -> String {
+    match phase {
+        Phase::Lint => "Lint".to_string(),
+        Phase::Generate { generator, scope } => format!("Generate ({generator}/{scope})"),
+        Phase::Compile { generator, scope } => format!("Compile ({generator}/{scope})"),
     }
 }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -426,9 +426,15 @@ impl App {
         &[]
     }
 
-    /// The currently selected error, if any.
+    /// The currently selected lint error, if any.
     pub fn selected_error(&self) -> Option<&LintError> {
         let errors = self.current_errors();
+        errors.get(self.error_index)
+    }
+
+    /// The currently selected compile error, if any.
+    pub fn selected_compile_error(&self) -> Option<&CompileError> {
+        let errors = self.current_compile_errors();
         errors.get(self.error_index)
     }
 

--- a/src/app/trace.rs
+++ b/src/app/trace.rs
@@ -292,6 +292,9 @@ pub struct SpecNames {
     pub operation_ids: Vec<String>,
     /// Tag names.
     pub tags: Vec<String>,
+    /// API path segments (e.g. "/pets", "/orders/{orderId}").
+    /// Stored as decoded path segments (with `~1` → `/` unescaped).
+    pub api_paths: Vec<String>,
 }
 
 impl SpecNames {
@@ -310,14 +313,35 @@ impl SpecNames {
                 }
             }
 
-            // /paths/{path}/{method}/operationId (won't be in pointers directly,
-            // but /paths/{path}/{method} gives us operation groups)
-
-            // /paths/{path}/{method} — extract path-based operation groups.
-            // We can't resolve operationId values from pointers alone (they're leaf
-            // values, not keys), but the path segment gives us the operation group.
+            // /paths/{path}/{method} — extract the API path and derive resource names.
+            if parts.len() >= 3 && parts[1] == "paths" {
+                let raw_path = parts[2].replace("~1", "/").replace("~0", "~");
+                if !names.api_paths.contains(&raw_path) {
+                    names.api_paths.push(raw_path);
+                }
+            }
         }
 
+        names
+    }
+
+    /// Derive searchable resource names from API paths.
+    ///
+    /// `/pets` → `"pets"`, `/pets/{petId}` → `"pets"`,
+    /// `/users/{userId}/orders` → `"orders"`, `"users"`.
+    pub fn path_resource_names(&self) -> Vec<String> {
+        let mut names = Vec::new();
+        for path in &self.api_paths {
+            for segment in path.split('/') {
+                if segment.is_empty() || segment.starts_with('{') {
+                    continue;
+                }
+                let lower = segment.to_ascii_lowercase();
+                if !names.contains(&lower) {
+                    names.push(lower);
+                }
+            }
+        }
         names
     }
 }
@@ -373,6 +397,27 @@ fn name_based_match(file_stem: &str, rel_path: &Path, names: &SpecNames) -> Vec<
         // Direct or suffixed match in api directories.
         if is_api_dir && (stem_lower == op_lower || stem_lower.contains(&op_lower)) {
             matches.push(op_id.clone());
+        }
+    }
+
+    // Match API path resource names against files in api-like directories.
+    // e.g., /pets → PetsApi.java, pets_controller.py, PetsService.ts
+    let resource_names = names.path_resource_names();
+    for resource in &resource_names {
+        if stem_lower.contains(resource) && (is_api_dir || stem_lower.ends_with("api")) {
+            // Store the original API path for trace-back.
+            let api_path = names
+                .api_paths
+                .iter()
+                .find(|p| {
+                    p.split('/')
+                        .any(|seg| seg.to_ascii_lowercase() == *resource)
+                })
+                .cloned()
+                .unwrap_or_else(|| resource.clone());
+            if !matches.contains(&api_path) {
+                matches.push(api_path);
+            }
         }
     }
 
@@ -595,6 +640,31 @@ Some random noise
         ];
         let names = SpecNames::from_pointers(&pointers);
         assert_eq!(names.schemas, vec!["Pet", "Order"]);
+        assert_eq!(names.api_paths, vec!["/pets"]);
+    }
+
+    #[test]
+    fn path_resource_names_extracts_segments() {
+        let names = SpecNames {
+            api_paths: vec!["/pets".into(), "/users/{userId}/orders".into()],
+            ..Default::default()
+        };
+        let resources = names.path_resource_names();
+        assert!(resources.contains(&"pets".to_string()));
+        assert!(resources.contains(&"users".to_string()));
+        assert!(resources.contains(&"orders".to_string()));
+        // {userId} is a parameter, not a resource
+        assert!(!resources.iter().any(|r| r.contains('{')));
+    }
+
+    #[test]
+    fn name_match_api_path_resource() {
+        let names = SpecNames {
+            api_paths: vec!["/pets".into()],
+            ..Default::default()
+        };
+        let m = name_based_match("PetsApi", Path::new("api/PetsApi.java"), &names);
+        assert!(m.contains(&"/pets".to_string()));
     }
 
     // ── Name-based matching ──────────────────────────────────────────

--- a/src/app/trace.rs
+++ b/src/app/trace.rs
@@ -1,0 +1,661 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use walkdir::WalkDir;
+
+/// A single error parsed from a compile log.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct CompileError {
+    /// Path relative to the generated output root.
+    pub file: PathBuf,
+    pub line: usize,
+    pub col: Option<usize>,
+    pub message: String,
+}
+
+/// Bidirectional mapping between spec constructs and generated files.
+#[derive(Debug, Clone, Default)]
+pub struct TraceIndex {
+    /// Spec construct name (e.g. "Pet", "listPets") → generated file relative paths.
+    pub spec_to_files: HashMap<String, Vec<PathBuf>>,
+    /// Generated file relative path → likely spec construct names.
+    pub file_to_spec: HashMap<PathBuf, Vec<String>>,
+}
+
+// ── Compile error parsing ──────────────────────────────────────────────
+
+/// Parse compile log output into structured errors.
+///
+/// Recognizes patterns for Java/Kotlin, TypeScript, Go, Python, and C#.
+/// Container paths (`/work/.oav/generated/...`) are stripped to relative paths.
+pub fn parse_compile_errors(log: &str) -> Vec<CompileError> {
+    let mut errors = Vec::new();
+    for line in log.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Some(err) = try_java_kotlin(trimmed)
+            .or_else(|| try_typescript(trimmed))
+            .or_else(|| try_go(trimmed))
+            .or_else(|| try_python(trimmed))
+            .or_else(|| try_csharp(trimmed))
+        {
+            errors.push(err);
+        }
+    }
+    errors
+}
+
+/// Java/Kotlin: `path/File.java:42: error: message`
+fn try_java_kotlin(line: &str) -> Option<CompileError> {
+    // Must contain ": error:" or ": warning:" to be a real compile line.
+    let error_marker = line.find(": error:").or_else(|| line.find(": warning:"))?;
+
+    // Find the file:line portion before the marker.
+    let prefix = &line[..error_marker];
+    let colon = prefix.rfind(':')?;
+    let file_str = &prefix[..colon];
+    let line_str = &prefix[colon + 1..];
+    let line_num: usize = line_str.parse().ok()?;
+
+    // Require it looks like a source file.
+    if !file_str.ends_with(".java")
+        && !file_str.ends_with(".kt")
+        && !file_str.ends_with(".kts")
+        && !file_str.ends_with(".scala")
+    {
+        return None;
+    }
+
+    let message = line[error_marker + 2..].trim().to_string();
+
+    Some(CompileError {
+        file: normalize_container_path(file_str),
+        line: line_num,
+        col: None,
+        message,
+    })
+}
+
+/// TypeScript: `path/file.ts(42,10): error TS2345: message`
+/// Also: C#-style `path/File.cs(42,10): error CS0001: message`
+fn try_typescript(line: &str) -> Option<CompileError> {
+    let paren = line.find('(')?;
+    let close_paren = line[paren..].find(')')? + paren;
+    let file_str = &line[..paren];
+
+    if !file_str.ends_with(".ts")
+        && !file_str.ends_with(".tsx")
+        && !file_str.ends_with(".js")
+        && !file_str.ends_with(".mts")
+    {
+        return None;
+    }
+
+    let loc = &line[paren + 1..close_paren];
+    let (line_num, col) = parse_comma_loc(loc)?;
+
+    let rest = line[close_paren + 1..].trim();
+    let message = rest.strip_prefix(':').unwrap_or(rest).trim().to_string();
+
+    Some(CompileError {
+        file: normalize_container_path(file_str),
+        line: line_num,
+        col: Some(col),
+        message,
+    })
+}
+
+/// Go: `path/file.go:42:10: message`
+fn try_go(line: &str) -> Option<CompileError> {
+    // Pattern: file.go:line:col: message
+    let parts: Vec<&str> = line.splitn(4, ':').collect();
+    if parts.len() < 3 {
+        return None;
+    }
+
+    let file_str = parts[0];
+    if !file_str.ends_with(".go") {
+        return None;
+    }
+
+    let line_num: usize = parts[1].trim().parse().ok()?;
+    let col: usize = parts[2].trim().parse().ok().unwrap_or(0);
+    let message = if parts.len() > 3 {
+        parts[3].trim().to_string()
+    } else {
+        String::new()
+    };
+
+    Some(CompileError {
+        file: normalize_container_path(file_str),
+        line: line_num,
+        col: if col > 0 { Some(col) } else { None },
+        message,
+    })
+}
+
+/// Python: `  File "path/file.py", line 42`
+fn try_python(line: &str) -> Option<CompileError> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with("File \"") {
+        return None;
+    }
+    let after_quote = &trimmed[6..]; // skip 'File "'
+    let end_quote = after_quote.find('"')?;
+    let file_str = &after_quote[..end_quote];
+
+    if !file_str.ends_with(".py") && !file_str.ends_with(".pyi") {
+        return None;
+    }
+
+    let rest = &after_quote[end_quote + 1..];
+    let line_marker = rest.find("line ")?;
+    let line_start = line_marker + 5;
+    let line_end = rest[line_start..]
+        .find(|c: char| !c.is_ascii_digit())
+        .map(|i| line_start + i)
+        .unwrap_or(rest.len());
+    let line_num: usize = rest[line_start..line_end].parse().ok()?;
+
+    Some(CompileError {
+        file: normalize_container_path(file_str),
+        line: line_num,
+        col: None,
+        message: String::new(),
+    })
+}
+
+/// C#: `path/File.cs(42,10): error CS0001: message`
+fn try_csharp(line: &str) -> Option<CompileError> {
+    let paren = line.find('(')?;
+    let close_paren = line[paren..].find(')')? + paren;
+    let file_str = &line[..paren];
+
+    if !file_str.ends_with(".cs") {
+        return None;
+    }
+
+    let loc = &line[paren + 1..close_paren];
+    let (line_num, col) = parse_comma_loc(loc)?;
+
+    let rest = line[close_paren + 1..].trim();
+    let message = rest.strip_prefix(':').unwrap_or(rest).trim().to_string();
+
+    Some(CompileError {
+        file: normalize_container_path(file_str),
+        line: line_num,
+        col: Some(col),
+        message,
+    })
+}
+
+fn parse_comma_loc(loc: &str) -> Option<(usize, usize)> {
+    let (l, c) = loc.split_once(',')?;
+    Some((l.trim().parse().ok()?, c.trim().parse().ok()?))
+}
+
+/// Strip container path prefixes so we get a path relative to the generated root.
+///
+/// Docker mounts at `/work`, so paths like `/work/.oav/generated/server/spring/src/Foo.java`
+/// become `src/Foo.java` (relative to the generator output directory).
+fn normalize_container_path(raw: &str) -> PathBuf {
+    let path = raw.trim();
+
+    // Strip `/work/.oav/generated/{scope}/{generator}/` prefix.
+    if let Some(idx) = path.find(".oav/generated/") {
+        let after = &path[idx + ".oav/generated/".len()..];
+        // Skip the next two path segments (scope/generator).
+        let rest = after.splitn(3, '/').nth(2).unwrap_or(after);
+        return PathBuf::from(rest);
+    }
+
+    // Strip `/work/` prefix if present.
+    if let Some(rest) = path.strip_prefix("/work/") {
+        return PathBuf::from(rest);
+    }
+
+    PathBuf::from(path)
+}
+
+// ── Spec ↔ codegen mapping ─────────────────────────────────────────────
+
+/// Build a trace index by scanning generated files for spec construct references.
+///
+/// Uses multiple heuristics:
+/// 1. Name-based: model file names → schema names, api file names → operation groups
+/// 2. Comment-based: scan for `@Schema`, JSON pointers, operationId in generated code
+/// 3. Structure-based: `model/` dirs → schemas, `api/` dirs → operations
+pub fn build_trace_index(generated_dir: &Path, spec_names: &SpecNames) -> TraceIndex {
+    let mut index = TraceIndex::default();
+
+    if !generated_dir.is_dir() {
+        return index;
+    }
+
+    let walker = WalkDir::new(generated_dir)
+        .min_depth(1)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file());
+
+    for entry in walker {
+        let abs_path = entry.path();
+        let rel_path = abs_path
+            .strip_prefix(generated_dir)
+            .unwrap_or(abs_path)
+            .to_path_buf();
+
+        let file_stem = abs_path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+
+        // Strategy 1: Name-based matching against schema and operation names.
+        let matched_names = name_based_match(file_stem, &rel_path, spec_names);
+
+        // Strategy 2: Comment-based — scan file content for spec references.
+        let content_matches = if is_source_file(abs_path) {
+            comment_based_match(abs_path, spec_names)
+        } else {
+            Vec::new()
+        };
+
+        let mut all_matches: Vec<String> = matched_names;
+        for m in content_matches {
+            if !all_matches.contains(&m) {
+                all_matches.push(m);
+            }
+        }
+
+        if !all_matches.is_empty() {
+            for name in &all_matches {
+                index
+                    .spec_to_files
+                    .entry(name.clone())
+                    .or_default()
+                    .push(rel_path.clone());
+            }
+            index.file_to_spec.insert(rel_path, all_matches);
+        }
+    }
+
+    index
+}
+
+/// Known spec construct names extracted from a SpecIndex.
+#[derive(Debug, Clone, Default)]
+#[allow(dead_code)]
+pub struct SpecNames {
+    /// Schema names (e.g. "Pet", "Order").
+    pub schemas: Vec<String>,
+    /// Operation IDs (e.g. "listPets", "createOrder").
+    pub operation_ids: Vec<String>,
+    /// Tag names.
+    pub tags: Vec<String>,
+}
+
+impl SpecNames {
+    /// Extract spec construct names from the SpecIndex's JSON pointers.
+    pub fn from_pointers(pointers: &[String]) -> Self {
+        let mut names = Self::default();
+
+        for pointer in pointers {
+            let parts: Vec<&str> = pointer.split('/').collect();
+
+            // /components/schemas/{Name}
+            if parts.len() >= 4 && parts[1] == "components" && parts[2] == "schemas" {
+                let name = parts[3].to_string();
+                if !names.schemas.contains(&name) {
+                    names.schemas.push(name);
+                }
+            }
+
+            // /paths/{path}/{method}/operationId (won't be in pointers directly,
+            // but /paths/{path}/{method} gives us operation groups)
+
+            // /paths/{path}/{method} — extract path-based operation groups.
+            // We can't resolve operationId values from pointers alone (they're leaf
+            // values, not keys), but the path segment gives us the operation group.
+        }
+
+        names
+    }
+}
+
+/// Name-based heuristic: match file stem and path against known spec names.
+fn name_based_match(file_stem: &str, rel_path: &Path, names: &SpecNames) -> Vec<String> {
+    let mut matches = Vec::new();
+    let stem_lower = file_stem.to_ascii_lowercase();
+    let path_str = rel_path.to_string_lossy().to_ascii_lowercase();
+
+    // Check if path is in a model-like directory.
+    let is_model_dir = path_str.contains("/model/")
+        || path_str.contains("/models/")
+        || path_str.contains("/dto/")
+        || path_str.contains("/entity/")
+        || path_str.contains("/schema/")
+        || path_str.contains("/schemas/");
+
+    // Check if path is in an api-like directory.
+    let is_api_dir = path_str.contains("/api/")
+        || path_str.contains("/apis/")
+        || path_str.contains("/controller/")
+        || path_str.contains("/controllers/")
+        || path_str.contains("/resource/")
+        || path_str.contains("/resources/");
+
+    for schema in &names.schemas {
+        let schema_lower = schema.to_ascii_lowercase();
+
+        // Direct match: Pet.java → Pet
+        if stem_lower == schema_lower {
+            matches.push(schema.clone());
+            continue;
+        }
+
+        // Suffixed match: PetDto.java, PetModel.java, PetResponse.java
+        if stem_lower.starts_with(&schema_lower)
+            && (is_model_dir || stem_lower.len() <= schema_lower.len() + 10)
+        {
+            let suffix = &stem_lower[schema_lower.len()..];
+            if matches!(
+                suffix,
+                "dto" | "model" | "entity" | "response" | "request" | "schema" | "vo" | "bean"
+            ) {
+                matches.push(schema.clone());
+            }
+        }
+    }
+
+    for op_id in &names.operation_ids {
+        let op_lower = op_id.to_ascii_lowercase();
+
+        // Direct or suffixed match in api directories.
+        if is_api_dir && (stem_lower == op_lower || stem_lower.contains(&op_lower)) {
+            matches.push(op_id.clone());
+        }
+    }
+
+    matches
+}
+
+/// Check if a file is a source file worth scanning for comments.
+fn is_source_file(path: &Path) -> bool {
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    matches!(
+        ext.to_ascii_lowercase().as_str(),
+        "java"
+            | "kt"
+            | "kts"
+            | "ts"
+            | "tsx"
+            | "js"
+            | "go"
+            | "py"
+            | "cs"
+            | "scala"
+            | "swift"
+            | "rs"
+            | "rb"
+            | "dart"
+            | "php"
+    )
+}
+
+/// Scan file content for spec references in comments/annotations.
+fn comment_based_match(path: &Path, names: &SpecNames) -> Vec<String> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    // Cap scan size to avoid reading huge files.
+    let scan = if content.len() > 256 * 1024 {
+        &content[..256 * 1024]
+    } else {
+        &content
+    };
+
+    let mut matches = Vec::new();
+
+    for schema in &names.schemas {
+        // @Schema(name = "Pet") — Java/Kotlin OpenAPI annotations
+        if scan.contains(&format!("@Schema(name = \"{schema}\""))
+            || scan.contains(&format!("@Schema(name=\"{schema}\""))
+        {
+            if !matches.contains(schema) {
+                matches.push(schema.clone());
+            }
+            continue;
+        }
+
+        // JSON pointer in comment: #/components/schemas/Pet
+        if scan.contains(&format!("#/components/schemas/{schema}"))
+            || scan.contains(&format!("/components/schemas/{schema}"))
+        {
+            if !matches.contains(schema) {
+                matches.push(schema.clone());
+            }
+            continue;
+        }
+
+        // TypeScript/JS: interface Pet or type Pet or export class Pet
+        if (scan.contains(&format!("interface {schema}"))
+            || scan.contains(&format!("type {schema} "))
+            || scan.contains(&format!("class {schema}"))
+            || scan.contains(&format!("struct {schema}")))
+            && !matches.contains(schema)
+        {
+            matches.push(schema.clone());
+        }
+    }
+
+    for op_id in &names.operation_ids {
+        // operationId in comment or as method name
+        if (scan.contains(&format!("operationId: {op_id}"))
+            || scan.contains(&format!("operationId: \"{op_id}\""))
+            || scan.contains(&format!("operation_id = \"{op_id}\"")))
+            && !matches.contains(op_id)
+        {
+            matches.push(op_id.clone());
+        }
+    }
+
+    matches
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Compile error parsing ────────────────────────────────────────
+
+    #[test]
+    fn java_error() {
+        let log = "src/main/java/com/example/Pet.java:42: error: cannot find symbol";
+        let errors = parse_compile_errors(log);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(
+            errors[0].file,
+            PathBuf::from("src/main/java/com/example/Pet.java")
+        );
+        assert_eq!(errors[0].line, 42);
+        assert!(errors[0].message.contains("cannot find symbol"));
+    }
+
+    #[test]
+    fn java_container_path() {
+        let log = "/work/.oav/generated/server/spring/src/Pet.java:10: error: missing";
+        let errors = parse_compile_errors(log);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].file, PathBuf::from("src/Pet.java"));
+        assert_eq!(errors[0].line, 10);
+    }
+
+    #[test]
+    fn typescript_error() {
+        let log = "src/models/Pet.ts(42,10): error TS2345: Argument of type 'string'";
+        let errors = parse_compile_errors(log);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].file, PathBuf::from("src/models/Pet.ts"));
+        assert_eq!(errors[0].line, 42);
+        assert_eq!(errors[0].col, Some(10));
+    }
+
+    #[test]
+    fn go_error() {
+        let log = "pkg/api/pet.go:15:2: undefined: PetStore";
+        let errors = parse_compile_errors(log);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].file, PathBuf::from("pkg/api/pet.go"));
+        assert_eq!(errors[0].line, 15);
+        assert_eq!(errors[0].col, Some(2));
+        assert!(errors[0].message.contains("undefined"));
+    }
+
+    #[test]
+    fn python_error() {
+        let log = "  File \"models/pet.py\", line 23, in <module>";
+        let errors = parse_compile_errors(log);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].file, PathBuf::from("models/pet.py"));
+        assert_eq!(errors[0].line, 23);
+    }
+
+    #[test]
+    fn csharp_error() {
+        let log = "Models/Pet.cs(15,8): error CS0246: The type or namespace name 'Pet'";
+        let errors = parse_compile_errors(log);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].file, PathBuf::from("Models/Pet.cs"));
+        assert_eq!(errors[0].line, 15);
+        assert_eq!(errors[0].col, Some(8));
+    }
+
+    #[test]
+    fn multi_language_mixed() {
+        let log = "\
+src/Pet.java:5: error: semicolon expected
+src/api.ts(10,1): error TS1005: ';' expected
+main.go:3:1: syntax error
+  File \"app.py\", line 1
+";
+        let errors = parse_compile_errors(log);
+        assert_eq!(errors.len(), 4);
+    }
+
+    #[test]
+    fn empty_and_noise() {
+        let log = "\
+BUILD FAILED
+Some random noise
+  at org.gradle.internal.something
+
+";
+        let errors = parse_compile_errors(log);
+        assert!(errors.is_empty());
+    }
+
+    // ── Container path normalization ─────────────────────────────────
+
+    #[test]
+    fn normalize_strips_work_prefix() {
+        assert_eq!(
+            normalize_container_path("/work/src/Foo.java"),
+            PathBuf::from("src/Foo.java")
+        );
+    }
+
+    #[test]
+    fn normalize_strips_generated_prefix() {
+        assert_eq!(
+            normalize_container_path("/work/.oav/generated/server/spring/src/Foo.java"),
+            PathBuf::from("src/Foo.java")
+        );
+    }
+
+    #[test]
+    fn normalize_keeps_relative() {
+        assert_eq!(
+            normalize_container_path("src/Foo.java"),
+            PathBuf::from("src/Foo.java")
+        );
+    }
+
+    // ── SpecNames extraction ─────────────────────────────────────────
+
+    #[test]
+    fn spec_names_from_pointers() {
+        let pointers = vec![
+            "/components/schemas/Pet".to_string(),
+            "/components/schemas/Pet/properties/name".to_string(),
+            "/components/schemas/Order".to_string(),
+            "/paths/~1pets/get".to_string(),
+            "/paths/~1pets/get/summary".to_string(),
+        ];
+        let names = SpecNames::from_pointers(&pointers);
+        assert_eq!(names.schemas, vec!["Pet", "Order"]);
+    }
+
+    // ── Name-based matching ──────────────────────────────────────────
+
+    #[test]
+    fn name_match_direct() {
+        let names = SpecNames {
+            schemas: vec!["Pet".into()],
+            ..Default::default()
+        };
+        let m = name_based_match("Pet", Path::new("model/Pet.java"), &names);
+        assert_eq!(m, vec!["Pet"]);
+    }
+
+    #[test]
+    fn name_match_suffixed_in_model_dir() {
+        let names = SpecNames {
+            schemas: vec!["Pet".into()],
+            ..Default::default()
+        };
+        let m = name_based_match("PetDto", Path::new("model/PetDto.java"), &names);
+        assert_eq!(m, vec!["Pet"]);
+    }
+
+    #[test]
+    fn name_match_case_insensitive() {
+        let names = SpecNames {
+            schemas: vec!["Pet".into()],
+            ..Default::default()
+        };
+        let m = name_based_match("pet", Path::new("models/pet.py"), &names);
+        assert_eq!(m, vec!["Pet"]);
+    }
+
+    #[test]
+    fn name_no_match_unrelated() {
+        let names = SpecNames {
+            schemas: vec!["Pet".into()],
+            ..Default::default()
+        };
+        let m = name_based_match("Utils", Path::new("util/Utils.java"), &names);
+        assert!(m.is_empty());
+    }
+
+    // ── Comment-based matching ───────────────────────────────────────
+
+    #[test]
+    fn comment_match_in_tempfile() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("Pet.java");
+        let mut f = std::fs::File::create(&file).unwrap();
+        writeln!(f, "// Generated from #/components/schemas/Pet").unwrap();
+        writeln!(f, "@Schema(name = \"Pet\")").unwrap();
+        writeln!(f, "public class Pet {{}}").unwrap();
+
+        let names = SpecNames {
+            schemas: vec!["Pet".into(), "Order".into()],
+            ..Default::default()
+        };
+        let m = comment_based_match(&file, &names);
+        assert_eq!(m, vec!["Pet"]);
+    }
+}

--- a/src/app/trace.rs
+++ b/src/app/trace.rs
@@ -243,6 +243,12 @@ pub fn build_trace_index(generated_dir: &Path, spec_names: &SpecNames) -> TraceI
 
     for entry in walker {
         let abs_path = entry.path();
+
+        // Skip non-source files (build artifacts like .class, .pyc, .o, etc.)
+        if !is_source_file(abs_path) {
+            continue;
+        }
+
         let rel_path = abs_path
             .strip_prefix(generated_dir)
             .unwrap_or(abs_path)
@@ -254,11 +260,7 @@ pub fn build_trace_index(generated_dir: &Path, spec_names: &SpecNames) -> TraceI
         let matched_names = name_based_match(file_stem, &rel_path, spec_names);
 
         // Strategy 2: Comment-based — scan file content for spec references.
-        let content_matches = if is_source_file(abs_path) {
-            comment_based_match(abs_path, spec_names)
-        } else {
-            Vec::new()
-        };
+        let content_matches = comment_based_match(abs_path, spec_names);
 
         let mut all_matches: Vec<String> = matched_names;
         for m in content_matches {

--- a/src/highlight/mod.rs
+++ b/src/highlight/mod.rs
@@ -18,8 +18,8 @@ struct CachedHighlight {
 
 impl HighlightEngine {
     pub fn new() -> Self {
-        let syntax_set = SyntaxSet::load_defaults_newlines();
-        let theme = ThemeSet::load_defaults().themes["base16-ocean.dark"].clone();
+        let syntax_set = two_face::syntax::extra_newlines();
+        let theme = ThemeSet::load_defaults().themes["base16-eighties.dark"].clone();
         Self {
             syntax_set,
             theme,
@@ -123,5 +123,44 @@ mod tests {
         let lines: Vec<String> = vec!["some content\n".into()];
         let result = engine.highlight_lines(&lines, "NoSuchLanguage", 0);
         assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn all_mapped_syntaxes_resolve() {
+        let ss = two_face::syntax::extra_newlines();
+        let mapped = [
+            "Java",
+            "Kotlin",
+            "TypeScript",
+            "JavaScript",
+            "Go",
+            "Python",
+            "Rust",
+            "C#",
+            "Ruby",
+            "Swift",
+            "C",
+            "C++",
+            "JSON",
+            "YAML",
+            "XML",
+            "HTML",
+            "CSS",
+            "Markdown",
+            "Bourne Again Shell (bash)",
+            "TOML",
+            "SQL",
+            "Groovy",
+            "Dart",
+            "PHP",
+            "Scala",
+            "Plain Text",
+        ];
+        for name in &mapped {
+            assert!(
+                ss.find_syntax_by_name(name).is_some(),
+                "Syntax not found by name: {name}"
+            );
+        }
     }
 }

--- a/src/keys/action.rs
+++ b/src/keys/action.rs
@@ -44,6 +44,10 @@ pub enum KeyAction {
     PrevGenerator,
     ToggleDiff,
     CloseDiff,
+
+    // Tracing
+    JumpToGenerated,
+    JumpToSpec,
 }
 
 impl KeyAction {
@@ -79,6 +83,8 @@ impl KeyAction {
         Self::PrevGenerator,
         Self::ToggleDiff,
         Self::CloseDiff,
+        Self::JumpToGenerated,
+        Self::JumpToSpec,
     ];
 
     /// The snake_case name used in `.oavc` config files.
@@ -115,6 +121,8 @@ impl KeyAction {
             Self::PrevGenerator => "prev_generator",
             Self::ToggleDiff => "toggle_diff",
             Self::CloseDiff => "close_diff",
+            Self::JumpToGenerated => "jump_to_generated",
+            Self::JumpToSpec => "jump_to_spec",
         }
     }
 
@@ -151,6 +159,8 @@ impl KeyAction {
             "prev_generator" => Self::PrevGenerator,
             "toggle_diff" => Self::ToggleDiff,
             "close_diff" => Self::CloseDiff,
+            "jump_to_generated" => Self::JumpToGenerated,
+            "jump_to_spec" => Self::JumpToSpec,
             _ => return None,
         })
     }
@@ -177,6 +187,6 @@ mod tests {
     #[test]
     fn all_array_is_exhaustive() {
         // Verify ALL contains the expected count. Update this if variants are added.
-        assert_eq!(KeyAction::ALL.len(), 31);
+        assert_eq!(KeyAction::ALL.len(), 33);
     }
 }

--- a/src/keys/keymap.rs
+++ b/src/keys/keymap.rs
@@ -125,6 +125,8 @@ fn default_bindings() -> Vec<(KeyAction, Vec<KeyInput>)> {
         (PrevGenerator, parse_keys(&["["])),
         (ToggleDiff, parse_keys(&["d"])),
         (CloseDiff, parse_keys(&["d", "Esc"])),
+        (JumpToGenerated, parse_keys(&["s"])),
+        (JumpToSpec, parse_keys(&["s"])),
     ]
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 
 use app::diff::{DiffPanel, DiffViewState};
+use app::trace;
 use app::{App, BrowserPanel, Panel, StatusLevel, ViewMode};
 use lazyoav::config;
 use lazyoav::custom;
@@ -315,6 +316,7 @@ fn handle_key(app: &mut App, key: KeyEvent) -> Action {
                 sync_generators_from_report(app);
                 if let Ok(cwd) = std::env::current_dir() {
                     app::browser::refresh_file_tree(&mut app.browser, &cwd);
+                    rebuild_trace_index(app, &cwd);
                 }
                 app.view_mode = ViewMode::CodeBrowser;
             }
@@ -441,6 +443,18 @@ fn handle_key(app: &mut App, key: KeyEvent) -> Action {
                     return Action::None;
                 };
                 return Action::OpenEditor { path, line };
+            } else if has(KeyAction::JumpToGenerated) {
+                // From a compile error, jump to the file in the code browser.
+                let compile_errors = app.current_compile_errors();
+                if !compile_errors.is_empty() {
+                    if let Some(phase_gen) = app.selected_phase_generator() {
+                        let generator = phase_gen.0.to_string();
+                        let scope = phase_gen.1.to_string();
+                        jump_to_compile_error(app, &generator, &scope);
+                    }
+                } else {
+                    jump_to_generated(app);
+                }
             } else if has(KeyAction::ProposeFix) {
                 let Some(error) = app.selected_error().cloned() else {
                     app.set_status("No error selected", StatusLevel::Info);
@@ -502,6 +516,8 @@ fn handle_key(app: &mut App, key: KeyEvent) -> Action {
                 app.spec_scroll = app.spec_scroll.saturating_sub(20);
             } else if has(KeyAction::PageDown) || has(KeyAction::HalfPageDown) {
                 app.spec_scroll = app.spec_scroll.saturating_add(20);
+            } else if has(KeyAction::JumpToGenerated) {
+                jump_to_generated(app);
             }
         }
     }
@@ -643,6 +659,7 @@ fn start_pipeline(app: &mut App) {
     // Clear previous state.
     app.report = None;
     app.lint_errors.clear();
+    app.compile_errors.clear();
     app.live_log.clear();
     app.phase_index = 0;
     app.error_index = 0;
@@ -670,6 +687,18 @@ fn drain_pipeline_events(app: &mut App) {
                 PipelineEvent::Completed(report) => {
                     if let Some(lint) = &report.phases.lint {
                         app.lint_errors = log_parser::parse_lint_log(&lint.log);
+                    }
+
+                    // Parse compile errors from compile logs.
+                    app.compile_errors.clear();
+                    if let Some(compile_steps) = &report.phases.compile {
+                        for step in compile_steps {
+                            let errors = trace::parse_compile_errors(&step.log);
+                            if !errors.is_empty() {
+                                let key = format!("{}/{}", step.generator, step.scope);
+                                app.compile_errors.insert(key, errors);
+                            }
+                        }
                     }
 
                     if let Some(gen_steps) = &report.phases.generate
@@ -757,6 +786,171 @@ fn sync_generators_from_report(app: &mut App) {
         app.browser.generator_index = 0;
     }
     app.browser.generators = generators;
+}
+
+/// Jump from spec context / lint error to the code browser, finding matching generated files.
+fn jump_to_generated(app: &mut App) {
+    // Try to find a spec construct name from the selected error or the current context.
+    let construct_name = if let Some(error) = app.selected_error() {
+        // Use JSON path to infer schema/operation name.
+        error
+            .json_path
+            .as_ref()
+            .and_then(|jp| extract_construct_name(jp))
+    } else {
+        None
+    };
+
+    let Some(name) = construct_name else {
+        app.set_status("No spec construct to trace", StatusLevel::Info);
+        return;
+    };
+
+    // Build trace index on the fly if needed.
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    sync_generators_from_report(app);
+    app::browser::refresh_file_tree(&mut app.browser, &cwd);
+    rebuild_trace_index(app, &cwd);
+
+    if let Some(trace) = &app.browser.trace_index
+        && let Some(files) = trace.spec_to_files.get(&name)
+        && let Some(first) = files.first()
+    {
+        // Find the file in the browser's file tree and select it.
+        if let Some(idx) = app.browser.file_tree.iter().position(|e| {
+            let gen_dir = app.browser.active_generator_dir().and_then(|d| {
+                std::env::current_dir()
+                    .ok()
+                    .map(|c| c.join(".oav/generated").join(d))
+            });
+            gen_dir
+                .as_ref()
+                .and_then(|gd| e.path.strip_prefix(gd).ok())
+                .is_some_and(|rel| rel == first.as_path())
+        }) {
+            app.browser.file_index = idx;
+            app::browser::load_selected_file(&mut app.browser);
+            app.browser.browser_focus = BrowserPanel::FileContent;
+        }
+        app.view_mode = ViewMode::CodeBrowser;
+        app.set_status(
+            format!("Found {} in generated output", name),
+            StatusLevel::Info,
+        );
+    } else {
+        app.set_status(
+            format!("No generated files found for '{name}'"),
+            StatusLevel::Info,
+        );
+    }
+}
+
+/// Jump from a compile error to the corresponding file in the code browser.
+fn jump_to_compile_error(app: &mut App, generator: &str, scope: &str) {
+    let key = format!("{generator}/{scope}");
+    let errors = match app.compile_errors.get(&key) {
+        Some(e) => e,
+        None => return,
+    };
+
+    let error = match errors.get(app.error_index) {
+        Some(e) => e.clone(),
+        None => return,
+    };
+
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    // Switch to the right generator in the browser.
+    sync_generators_from_report(app);
+    if let Some(idx) = app
+        .browser
+        .generators
+        .iter()
+        .position(|(g, s)| g == generator && s == scope)
+    {
+        app.browser.generator_index = idx;
+    }
+    app::browser::refresh_file_tree(&mut app.browser, &cwd);
+    rebuild_trace_index(app, &cwd);
+
+    // Find the error file in the tree.
+    let gen_dir = cwd
+        .join(".oav/generated")
+        .join(format!("{scope}/{generator}"));
+
+    if let Some(idx) = app.browser.file_tree.iter().position(|e| {
+        e.path
+            .strip_prefix(&gen_dir)
+            .ok()
+            .is_some_and(|rel| rel == error.file.as_path())
+    }) {
+        app.browser.file_index = idx;
+        app::browser::load_selected_file(&mut app.browser);
+        app.browser.browser_focus = BrowserPanel::FileContent;
+        // Scroll to the error line.
+        app.browser.file_scroll = error.line.saturating_sub(3) as u16;
+    }
+
+    app.view_mode = ViewMode::CodeBrowser;
+    app.set_status(
+        format!(
+            "{}:{} — {}",
+            error.file.display(),
+            error.line,
+            error.message
+        ),
+        StatusLevel::Info,
+    );
+}
+
+/// Extract a spec construct name (schema or operation) from a JSON path.
+fn extract_construct_name(json_path: &str) -> Option<String> {
+    let pointer = spec::normalize_to_pointer(json_path);
+    let parts: Vec<&str> = pointer.split('/').collect();
+
+    // /components/schemas/{Name}/...
+    if parts.len() >= 4 && parts[1] == "components" && parts[2] == "schemas" {
+        return Some(parts[3].replace("~1", "/").replace("~0", "~"));
+    }
+
+    // /paths/{path}/{method}/... — extract path segment as operation group
+    if parts.len() >= 4 && parts[1] == "paths" {
+        let path_seg = parts[2].replace("~1", "/").replace("~0", "~");
+        return Some(path_seg);
+    }
+
+    None
+}
+
+/// Rebuild the trace index for the active generator using spec construct names.
+fn rebuild_trace_index(app: &mut App, cwd: &Path) {
+    let spec_names = app
+        .spec_index
+        .as_ref()
+        .map(|si| trace::SpecNames::from_pointers(&si.pointers()))
+        .unwrap_or_default();
+
+    let gen_dir = match app.browser.active_generator_dir() {
+        Some(d) => cwd.join(".oav/generated").join(d),
+        None => {
+            app.browser.trace_index = None;
+            return;
+        }
+    };
+
+    let index = trace::build_trace_index(&gen_dir, &spec_names);
+    app.browser.trace_index = if index.spec_to_files.is_empty() && index.file_to_spec.is_empty() {
+        None
+    } else {
+        Some(index)
+    };
 }
 
 /// Handle keys when the code browser view is active.
@@ -864,6 +1058,57 @@ fn handle_browser_key(app: &mut App, input: KeyInput) -> Action {
         app::browser::load_selected_file(&mut app.browser);
         if app.browser.file_content.is_some() {
             app.browser.browser_focus = BrowserPanel::FileContent;
+        }
+    }
+    // Jump to spec origin from a generated file.
+    else if has(KeyAction::JumpToSpec) {
+        if let Some(trace) = &app.browser.trace_index
+            && let Some(idx) = app
+                .browser
+                .opened_file_index
+                .or(Some(app.browser.file_index))
+            && let Some(entry) = app.browser.file_tree.get(idx)
+        {
+            // Get the relative path within the generated dir.
+            let gen_dir = app.browser.active_generator_dir().and_then(|d| {
+                std::env::current_dir()
+                    .ok()
+                    .map(|cwd| cwd.join(".oav/generated").join(d))
+            });
+            let rel_path = gen_dir
+                .as_ref()
+                .and_then(|gd| entry.path.strip_prefix(gd).ok())
+                .map(|p| p.to_path_buf());
+
+            if let Some(rel) = rel_path
+                && let Some(spec_names) = trace.file_to_spec.get(&rel)
+                && !spec_names.is_empty()
+            {
+                // Find the first spec name that resolves in the spec index.
+                let target = spec_names.first().unwrap();
+                let pointer = format!("/components/schemas/{target}");
+                if let Some(ref si) = app.spec_index
+                    && let Some(span) = si.resolve(&pointer)
+                {
+                    app.view_mode = ViewMode::Validator;
+                    app.focused_panel = Panel::SpecContext;
+                    // Set spec scroll near the target line.
+                    app.spec_scroll = span.line.saturating_sub(3) as u16;
+                    app.set_status(
+                        format!("Jumped to spec origin: {target}"),
+                        StatusLevel::Info,
+                    );
+                } else {
+                    app.set_status(
+                        format!("Likely from: {}", spec_names.join(", ")),
+                        StatusLevel::Info,
+                    );
+                }
+            } else {
+                app.set_status("No spec origin found for this file", StatusLevel::Info);
+            }
+        } else {
+            app.set_status("No trace data available", StatusLevel::Info);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -762,6 +762,7 @@ fn drain_pipeline_events(app: &mut App) {
             sync_generators_from_report(app);
             if let Ok(cwd) = std::env::current_dir() {
                 app::browser::refresh_file_tree(&mut app.browser, &cwd);
+                rebuild_trace_index(app, &cwd);
             }
         }
     }
@@ -984,6 +985,7 @@ fn handle_browser_key(app: &mut App, input: KeyInput) -> Action {
                 (app.browser.generator_index + 1) % app.browser.generators.len();
             if let Ok(cwd) = std::env::current_dir() {
                 app::browser::refresh_file_tree(&mut app.browser, &cwd);
+                rebuild_trace_index(app, &cwd);
             }
         }
     } else if has(KeyAction::PrevGenerator) {
@@ -992,6 +994,7 @@ fn handle_browser_key(app: &mut App, input: KeyInput) -> Action {
             app.browser.generator_index = (app.browser.generator_index + len - 1) % len;
             if let Ok(cwd) = std::env::current_dir() {
                 app::browser::refresh_file_tree(&mut app.browser, &cwd);
+                rebuild_trace_index(app, &cwd);
             }
         }
     }
@@ -1084,15 +1087,26 @@ fn handle_browser_key(app: &mut App, input: KeyInput) -> Action {
                 && let Some(spec_names) = trace.file_to_spec.get(&rel)
                 && !spec_names.is_empty()
             {
-                // Find the first spec name that resolves in the spec index.
-                let target = spec_names.first().unwrap();
-                let pointer = format!("/components/schemas/{target}");
-                if let Some(ref si) = app.spec_index
-                    && let Some(span) = si.resolve(&pointer)
-                {
+                // Try to resolve each name as a spec pointer.
+                let resolved = spec_names.iter().find_map(|name| {
+                    let si = app.spec_index.as_ref()?;
+                    // Try as schema first, then as API path.
+                    let pointer = format!("/components/schemas/{name}");
+                    if let Some(span) = si.resolve(&pointer) {
+                        return Some((name.clone(), span));
+                    }
+                    // API path: name is like "/pets", pointer is /paths/~1pets
+                    let escaped = name.replace('~', "~0").replace('/', "~1");
+                    let pointer = format!("/paths/{escaped}");
+                    if let Some(span) = si.resolve(&pointer) {
+                        return Some((name.clone(), span));
+                    }
+                    None
+                });
+
+                if let Some((target, span)) = resolved {
                     app.view_mode = ViewMode::Validator;
                     app.focused_panel = Panel::SpecContext;
-                    // Set spec scroll near the target line.
                     app.spec_scroll = span.line.saturating_sub(3) as u16;
                     app.set_status(
                         format!("Jumped to spec origin: {target}"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use ratatui::backend::CrosstermBackend;
 
 use app::diff::{DiffPanel, DiffViewState};
 use app::trace;
-use app::{App, BrowserPanel, Panel, StatusLevel, ViewMode};
+use app::{App, BrowserPanel, Panel, PhaseStatus, StatusLevel, ViewMode};
 use lazyoav::config;
 use lazyoav::custom;
 use lazyoav::docker::{self, CancelToken};
@@ -76,12 +76,17 @@ fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
 
     while app.running {
         app.tick = app.tick.wrapping_add(1);
+
+        // Drain pipeline events BEFORE drawing so the frame always
+        // reflects the latest phase transitions and lint results.
+        drain_pipeline_events(&mut app);
+
         terminal.draw(|frame| ui::draw(frame, &app))?;
 
-        // Poll for input: use a short timeout while validating (to drain
-        // pipeline events promptly) and a longer one when idle to save CPU.
+        // Short poll during validation (~60 fps) so phase status updates
+        // render promptly.  Longer when idle to save CPU.
         let poll_timeout = if app.validating {
-            Duration::from_millis(50)
+            Duration::from_millis(16)
         } else {
             Duration::from_millis(200)
         };
@@ -96,8 +101,6 @@ fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
             }
             app.clamp_indices();
         }
-
-        drain_pipeline_events(&mut app);
     }
 
     Ok(())
@@ -661,6 +664,8 @@ fn start_pipeline(app: &mut App) {
     app.lint_errors.clear();
     app.compile_errors.clear();
     app.live_log.clear();
+    app.live_phases.clear();
+    app.live_lint_result = None;
     app.phase_index = 0;
     app.error_index = 0;
     app.detail_scroll = 0;
@@ -671,19 +676,48 @@ fn start_pipeline(app: &mut App) {
 }
 
 /// Drain pending pipeline events without blocking.
+///
+/// Processes at most `DRAIN_BUDGET` events per call so that parallel Docker
+/// processes producing high-volume log output cannot starve the draw/input
+/// cycle.  Structural events (phase transitions, completion) are always
+/// processed — only `Log` lines count against the budget.
+const DRAIN_BUDGET: usize = 256;
+
 fn drain_pipeline_events(app: &mut App) {
     let done = if let Some(rx) = &app.pipeline_rx {
         let mut finished = false;
+        let mut log_count = 0usize;
         while let Ok(ev) = rx.try_recv() {
             match ev {
-                PipelineEvent::PhaseStarted(_) => {
+                PipelineEvent::PhaseStarted(ref phase) => {
+                    app.live_phases.push((phase.clone(), PhaseStatus::Running));
                     app.live_log.clear();
                 }
                 PipelineEvent::Log { line, .. } => {
                     app.live_log.push_str(&line);
                     app.live_log.push('\n');
+                    log_count += 1;
+                    if log_count >= DRAIN_BUDGET {
+                        break;
+                    }
                 }
-                PipelineEvent::PhaseFinished { .. } => {}
+                PipelineEvent::PhaseFinished {
+                    ref phase, success, ..
+                } => {
+                    let status = if success {
+                        PhaseStatus::Pass
+                    } else {
+                        PhaseStatus::Fail
+                    };
+                    if let Some(entry) = app.live_phases.iter_mut().find(|(p, _)| p == phase) {
+                        entry.1 = status;
+                    }
+                }
+                PipelineEvent::LintCompleted(result) => {
+                    app.lint_errors = log_parser::parse_lint_log(&result.log);
+                    app.live_lint_result = Some(result);
+                    app.error_index = 0;
+                }
                 PipelineEvent::Completed(report) => {
                     if let Some(lint) = &report.phases.lint {
                         app.lint_errors = log_parser::parse_lint_log(&lint.log);
@@ -734,6 +768,8 @@ fn drain_pipeline_events(app: &mut App) {
                     app.report = Some(report);
                     app.validating = false;
                     app.live_log.clear();
+                    app.live_phases.clear();
+                    app.live_lint_result = None;
                     app.clamp_indices();
                     finished = true;
                     break;
@@ -742,6 +778,8 @@ fn drain_pipeline_events(app: &mut App) {
                     app.live_log
                         .push_str(&format!("\n--- Aborted: {reason} ---\n"));
                     app.snapshots.clear();
+                    app.live_phases.clear();
+                    app.live_lint_result = None;
                     app.validating = false;
                     finished = true;
                     break;

--- a/src/pipeline/commands.rs
+++ b/src/pipeline/commands.rs
@@ -124,7 +124,12 @@ pub fn compile_command(
     let compose_file = work_dir.join(".oav/docker-compose.yaml");
     let project_dir = work_dir.join(".oav");
 
-    let mut args = vec![
+    // Compile containers run as their image's default user (typically root)
+    // because build toolchains need full system access: package managers,
+    // native libraries, and writable cache directories.  The --user flag
+    // is intentionally omitted here — only generate commands need it so
+    // that output files are owned by the host user.
+    let args = vec![
         "compose".into(),
         "-f".into(),
         compose_file.display().to_string(),
@@ -132,9 +137,8 @@ pub fn compile_command(
         project_dir.display().to_string(),
         "run".into(),
         "--rm".into(),
+        service,
     ];
-    args.extend(docker::user_args());
-    args.push(service);
 
     ContainerCommand {
         args,
@@ -199,14 +203,16 @@ pub fn custom_compile_command(
     let cmd_args: Vec<String> =
         shell_words::split(&compile.command).unwrap_or_else(|_| vec![compile.command.clone()]);
 
+    // No --user for compile containers — same rationale as builtin compile_command.
     let mut args = vec![
         "run".into(),
         "--rm".into(),
         "-v".into(),
         format!("{}:/work", work_dir.display()),
+        "-w".into(),
+        workdir,
+        compile.image.clone(),
     ];
-    args.extend(docker::user_args());
-    args.extend(["-w".into(), workdir, compile.image.clone()]);
     args.extend(cmd_args);
 
     ContainerCommand {
@@ -411,13 +417,12 @@ mod tests {
         assert!(cmd.args.contains(&"build-spring".into()));
     }
 
-    #[cfg(unix)]
     #[test]
-    fn compile_command_passes_user_args() {
+    fn compile_command_omits_user_args() {
         let cfg = test_config();
         let cmd = compile_command(&cfg, Path::new("/tmp"), "spring", "server");
-        assert!(cmd.args.contains(&"--user".into()));
-        // Service name must come after --user so compose interprets it correctly
+        // Compile containers run as their image's default user — no --user flag.
+        assert!(!cmd.args.contains(&"--user".into()));
         assert_eq!(cmd.args.last().unwrap(), "build-spring");
     }
 

--- a/src/pipeline/orchestrator.rs
+++ b/src/pipeline/orchestrator.rs
@@ -59,16 +59,19 @@ fn run_inner(input: PipelineInput, cancel: CancelToken, tx: Sender<PipelineEvent
             failed += 1;
         }
 
-        phases.lint = Some(LintResult {
+        let lint_result = LintResult {
             linter: cfg.linter.as_str().to_string(),
             status: if lint_success { "pass" } else { "fail" }.to_string(),
             log: outcome.log,
-        });
+        };
 
         let _ = tx.send(PipelineEvent::PhaseFinished {
             phase: phase.clone(),
             success: lint_success,
         });
+        let _ = tx.send(PipelineEvent::LintCompleted(lint_result.clone()));
+
+        phases.lint = Some(lint_result);
 
         if cancel.is_cancelled() {
             let _ = tx.send(PipelineEvent::Aborted("Cancelled by user".into()));

--- a/src/pipeline/types.rs
+++ b/src/pipeline/types.rs
@@ -64,8 +64,17 @@ pub enum Phase {
 #[allow(dead_code)]
 pub enum PipelineEvent {
     PhaseStarted(Phase),
-    Log { phase: Phase, line: String },
-    PhaseFinished { phase: Phase, success: bool },
+    Log {
+        phase: Phase,
+        line: String,
+    },
+    PhaseFinished {
+        phase: Phase,
+        success: bool,
+    },
+    /// Sent immediately after lint finishes so the TUI can display
+    /// lint errors while generate/compile are still running.
+    LintCompleted(LintResult),
     Completed(ValidateReport),
     Aborted(String),
 }

--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -3,5 +3,5 @@ mod parser;
 mod types;
 
 pub use discovery::{discover_spec, normalize_spec_path};
-pub use parser::parse_spec;
+pub use parser::{normalize_to_pointer, parse_spec};
 pub use types::{ContextWindow, SourceSpan, SpecIndex};

--- a/src/spec/types.rs
+++ b/src/spec/types.rs
@@ -69,4 +69,9 @@ impl SpecIndex {
     pub fn lines(&self) -> &[String] {
         &self.raw_lines
     }
+
+    /// Return all JSON pointer keys in the index.
+    pub fn pointers(&self) -> Vec<String> {
+        self.spans.keys().cloned().collect()
+    }
 }

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -166,6 +166,7 @@ fn draw_bottom_bar(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
                     BrowserPanel::FileContent => {
                         let mut h = vec![
                             (scroll_label.as_str(), "scroll"),
+                            (km.label(KeyAction::JumpToSpec), "spec origin"),
                             (km.label(KeyAction::NextPanel), "panel"),
                             (km.label(KeyAction::ToggleView), "validator"),
                         ];
@@ -184,18 +185,27 @@ fn draw_bottom_bar(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
                     (km.label(KeyAction::RunValidation), "run"),
                     (km.label(KeyAction::ToggleView), "browser"),
                 ],
-                Panel::Errors => vec![
-                    (scroll_label.as_str(), "navigate"),
-                    (detail_label.as_str(), "detail"),
-                    (km.label(KeyAction::OpenEditor), "edit"),
-                    (km.label(KeyAction::ProposeFix), "fix"),
-                    (km.label(KeyAction::RunValidation), "run"),
-                ],
+                Panel::Errors => {
+                    let mut h = vec![
+                        (scroll_label.as_str(), "navigate"),
+                        (detail_label.as_str(), "detail"),
+                        (km.label(KeyAction::OpenEditor), "edit"),
+                        (km.label(KeyAction::ProposeFix), "fix"),
+                    ];
+                    if !app.current_compile_errors().is_empty() {
+                        h.push((km.label(KeyAction::JumpToGenerated), "go to source"));
+                    }
+                    h.push((km.label(KeyAction::RunValidation), "run"));
+                    h
+                }
                 Panel::Detail => vec![
                     (scroll_label.as_str(), "scroll"),
                     (tab_label.as_str(), "tab"),
                 ],
-                Panel::SpecContext => vec![(scroll_label.as_str(), "scroll")],
+                Panel::SpecContext => vec![
+                    (scroll_label.as_str(), "scroll"),
+                    (km.label(KeyAction::JumpToGenerated), "find in generated"),
+                ],
             }
         };
         if app.validating {

--- a/src/ui/panels/code_browser.rs
+++ b/src/ui/panels/code_browser.rs
@@ -6,7 +6,7 @@ use ratatui::widgets::{List, ListItem, ListState, Paragraph, Tabs, Wrap};
 
 use crate::app::browser::syntax_name_for_path;
 use crate::app::{App, BrowserPanel};
-use crate::ui::style::{COLOR_GUTTER, COLOR_SELECTED_BG, make_block};
+use crate::ui::style::{COLOR_GUTTER, STYLE_SELECTED, make_block};
 
 pub fn draw_code_browser(frame: &mut Frame, app: &App, area: Rect) {
     let horizontal = Layout::default()
@@ -94,11 +94,7 @@ fn draw_file_tree(frame: &mut Frame, app: &App, area: Rect) {
         })
         .collect();
 
-    let list = List::new(items).highlight_style(
-        Style::default()
-            .bg(COLOR_SELECTED_BG)
-            .add_modifier(Modifier::BOLD),
-    );
+    let list = List::new(items).highlight_style(STYLE_SELECTED);
 
     let mut list_state = ListState::default();
     list_state.select(Some(app.browser.file_index));

--- a/src/ui/panels/diff_browser.rs
+++ b/src/ui/panels/diff_browser.rs
@@ -6,7 +6,7 @@ use ratatui::widgets::{List, ListItem, ListState, Paragraph, Wrap};
 
 use crate::app::App;
 use crate::app::diff::{ChangeKind, DiffLine, DiffPanel};
-use crate::ui::style::{COLOR_GUTTER, COLOR_SELECTED_BG, make_block};
+use crate::ui::style::{COLOR_GUTTER, STYLE_SELECTED, make_block};
 
 pub fn draw_diff_browser(frame: &mut Frame, app: &App, area: Rect) {
     let horizontal = Layout::default()
@@ -83,11 +83,7 @@ fn draw_change_list(frame: &mut Frame, app: &App, area: Rect) {
         })
         .collect();
 
-    let list = List::new(items).highlight_style(
-        Style::default()
-            .bg(COLOR_SELECTED_BG)
-            .add_modifier(Modifier::BOLD),
-    );
+    let list = List::new(items).highlight_style(STYLE_SELECTED);
 
     let mut list_state = ListState::default();
     list_state.select(Some(app.browser.diff_state.file_index));

--- a/src/ui/panels/errors.rs
+++ b/src/ui/panels/errors.rs
@@ -1,27 +1,29 @@
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{List, ListItem, ListState};
 
 use crate::app::App;
 use crate::ui::style::{COLOR_SELECTED_BG, ICON_SEVERITY, make_block, severity_color};
 
-/// Truncate a string to at most `max` characters, appending "…" if shortened.
+/// Truncate a string to at most `max` characters, appending "..." if shortened.
 fn truncate_chars(s: &str, max: usize) -> String {
     let char_count = s.chars().count();
     if char_count <= max || max == 0 {
         return s.to_string();
     }
     let truncated: String = s.chars().take(max.saturating_sub(1)).collect();
-    format!("{truncated}…")
+    format!("{truncated}\u{2026}")
 }
 
 pub fn draw_errors(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
     let block = make_block("Errors", focused);
-    let errors = app.current_errors();
 
-    if errors.is_empty() {
+    let lint_errors = app.current_errors();
+    let compile_errors = app.current_compile_errors();
+
+    if lint_errors.is_empty() && compile_errors.is_empty() {
         let msg = if app.report.is_some() {
             "No errors in this phase"
         } else {
@@ -29,45 +31,66 @@ pub fn draw_errors(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
         };
         let item = ListItem::new(Line::from(Span::styled(
             msg,
-            Style::default().fg(ratatui::style::Color::DarkGray),
+            Style::default().fg(Color::DarkGray),
         )));
         let list = List::new(vec![item]).block(block);
         frame.render_widget(list, area);
         return;
     }
 
-    // Compute available width inside the block borders.
     let inner_width = area.width.saturating_sub(2) as usize;
 
-    let items: Vec<ListItem> = errors
-        .iter()
-        .enumerate()
-        .map(|(i, err)| {
-            let sev_color = severity_color(err.severity);
+    let items: Vec<ListItem> = if !lint_errors.is_empty() {
+        lint_errors
+            .iter()
+            .enumerate()
+            .map(|(i, err)| {
+                let sev_color = severity_color(err.severity);
+                let rule_display: String = truncate_chars(&err.rule, 20);
+                let prefix_len = 2 + rule_display.chars().count() + 2;
+                let msg_budget = inner_width.saturating_sub(prefix_len);
+                let msg_display: String = truncate_chars(&err.message, msg_budget);
 
-            // Truncate rule to ~20 chars (char-safe).
-            let rule_display: String = truncate_chars(&err.rule, 20);
+                let spans = vec![
+                    Span::styled(format!("{ICON_SEVERITY} "), Style::default().fg(sev_color)),
+                    Span::styled(rule_display, Style::default().add_modifier(Modifier::BOLD)),
+                    Span::raw("  "),
+                    Span::raw(msg_display),
+                ];
 
-            // "● rule_id  " takes up prefix_len chars.
-            let prefix_len = 2 + rule_display.chars().count() + 2; // icon+space + rule + 2 spaces
-            let msg_budget = inner_width.saturating_sub(prefix_len);
-            let msg_display: String = truncate_chars(&err.message, msg_budget);
+                let mut style = Style::default();
+                if focused && i == app.error_index {
+                    style = style.bg(COLOR_SELECTED_BG);
+                }
+                ListItem::new(Line::from(spans)).style(style)
+            })
+            .collect()
+    } else {
+        compile_errors
+            .iter()
+            .enumerate()
+            .map(|(i, err)| {
+                let loc = format!("{}:{}", err.file.display(), err.line);
+                let loc_display = truncate_chars(&loc, 30);
+                let prefix_len = 2 + loc_display.chars().count() + 2;
+                let msg_budget = inner_width.saturating_sub(prefix_len);
+                let msg_display = truncate_chars(&err.message, msg_budget);
 
-            let spans = vec![
-                Span::styled(format!("{ICON_SEVERITY} "), Style::default().fg(sev_color)),
-                Span::styled(rule_display, Style::default().add_modifier(Modifier::BOLD)),
-                Span::raw("  "),
-                Span::raw(msg_display),
-            ];
+                let spans = vec![
+                    Span::styled(format!("{ICON_SEVERITY} "), Style::default().fg(Color::Red)),
+                    Span::styled(loc_display, Style::default().add_modifier(Modifier::BOLD)),
+                    Span::raw("  "),
+                    Span::raw(msg_display),
+                ];
 
-            let mut style = Style::default();
-            if focused && i == app.error_index {
-                style = style.bg(COLOR_SELECTED_BG);
-            }
-
-            ListItem::new(Line::from(spans)).style(style)
-        })
-        .collect();
+                let mut style = Style::default();
+                if focused && i == app.error_index {
+                    style = style.bg(COLOR_SELECTED_BG);
+                }
+                ListItem::new(Line::from(spans)).style(style)
+            })
+            .collect()
+    };
 
     let mut state = ListState::default();
     if focused {

--- a/src/ui/panels/errors.rs
+++ b/src/ui/panels/errors.rs
@@ -5,7 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{List, ListItem, ListState};
 
 use crate::app::App;
-use crate::ui::style::{COLOR_SELECTED_BG, ICON_SEVERITY, make_block, severity_color};
+use crate::ui::style::{ICON_SEVERITY, STYLE_SELECTED, make_block, severity_color};
 
 /// Truncate a string to at most `max` characters, appending "..." if shortened.
 fn truncate_chars(s: &str, max: usize) -> String {
@@ -60,7 +60,7 @@ pub fn draw_errors(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
 
                 let mut style = Style::default();
                 if focused && i == app.error_index {
-                    style = style.bg(COLOR_SELECTED_BG);
+                    style = style.patch(STYLE_SELECTED);
                 }
                 ListItem::new(Line::from(spans)).style(style)
             })
@@ -85,7 +85,7 @@ pub fn draw_errors(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
 
                 let mut style = Style::default();
                 if focused && i == app.error_index {
-                    style = style.bg(COLOR_SELECTED_BG);
+                    style = style.patch(STYLE_SELECTED);
                 }
                 ListItem::new(Line::from(spans)).style(style)
             })
@@ -97,11 +97,9 @@ pub fn draw_errors(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
         state.select(Some(app.error_index));
     }
 
-    let list = List::new(items).block(block).highlight_style(
-        Style::default()
-            .bg(COLOR_SELECTED_BG)
-            .add_modifier(Modifier::BOLD),
-    );
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(STYLE_SELECTED);
 
     frame.render_stateful_widget(list, area, &mut state);
 }

--- a/src/ui/panels/phases.rs
+++ b/src/ui/panels/phases.rs
@@ -1,12 +1,12 @@
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
+use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{List, ListItem, ListState};
 
 use crate::app::App;
 use crate::ui::style::{
-    COLOR_FAIL, COLOR_SELECTED_BG, make_block, phase_status_color, phase_status_icon,
+    COLOR_FAIL, STYLE_SELECTED, make_block, phase_status_color, phase_status_icon,
 };
 
 pub fn draw_phases(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
@@ -44,7 +44,7 @@ pub fn draw_phases(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
 
             let mut style = Style::default();
             if focused && i == app.phase_index {
-                style = style.bg(COLOR_SELECTED_BG);
+                style = style.patch(STYLE_SELECTED);
             }
 
             ListItem::new(Line::from(spans)).style(style)
@@ -56,11 +56,9 @@ pub fn draw_phases(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
         state.select(Some(app.phase_index));
     }
 
-    let list = List::new(items).block(block).highlight_style(
-        Style::default()
-            .bg(COLOR_SELECTED_BG)
-            .add_modifier(Modifier::BOLD),
-    );
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(STYLE_SELECTED);
 
     frame.render_stateful_widget(list, area, &mut state);
 }

--- a/src/ui/panels/spec_context.rs
+++ b/src/ui/panels/spec_context.rs
@@ -5,6 +5,8 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Wrap};
 
 use crate::app::App;
+use crate::app::trace::CompileError;
+use crate::spec::SpecIndex;
 use crate::ui::style::{COLOR_GUTTER, STYLE_HIGHLIGHT_LINE, make_block};
 
 pub fn draw_spec_context(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
@@ -19,42 +21,24 @@ pub fn draw_spec_context(frame: &mut Frame, app: &App, area: Rect, focused: bool
     let spec_index = match &app.spec_index {
         Some(idx) => idx,
         None => {
-            let empty = Paragraph::new(Line::from(Span::styled(
-                "No spec context available",
-                Style::default().fg(Color::DarkGray),
-            )));
-            frame.render_widget(empty, inner);
+            render_empty(frame, inner);
             return;
         }
     };
 
-    // Resolve the target line from the selected error.
-    // Priority: json_path resolution → raw line number from linter output.
-    let target_line = app.selected_error().and_then(|err| {
-        err.json_path
-            .as_ref()
-            .and_then(|path| spec_index.resolve(path))
-            .map(|span| span.line)
-            .or(Some(err.line).filter(|&l| l > 0))
-    });
+    // Resolve target line: lint errors first, then compile errors.
+    let target_line = resolve_lint_target(app, spec_index)
+        .or_else(|| resolve_compile_target(app, spec_index));
 
     let radius = (inner.height as usize) / 2;
 
     let Some(target) = target_line else {
-        let empty = Paragraph::new(Line::from(Span::styled(
-            "No spec context available",
-            Style::default().fg(Color::DarkGray),
-        )));
-        frame.render_widget(empty, inner);
+        render_empty(frame, inner);
         return;
     };
 
     let Some(window) = spec_index.context_window(target, radius) else {
-        let empty = Paragraph::new(Line::from(Span::styled(
-            "No spec context available",
-            Style::default().fg(Color::DarkGray),
-        )));
-        frame.render_widget(empty, inner);
+        render_empty(frame, inner);
         return;
     };
 
@@ -109,4 +93,91 @@ pub fn draw_spec_context(frame: &mut Frame, app: &App, area: Rect, focused: bool
         .scroll((app.spec_scroll, 0));
 
     frame.render_widget(paragraph, inner);
+}
+
+fn render_empty(frame: &mut Frame, area: Rect) {
+    let empty = Paragraph::new(Line::from(Span::styled(
+        "No spec context available",
+        Style::default().fg(Color::DarkGray),
+    )));
+    frame.render_widget(empty, area);
+}
+
+/// Resolve spec target line from a selected lint error.
+fn resolve_lint_target(app: &App, spec_index: &SpecIndex) -> Option<usize> {
+    app.selected_error().and_then(|err| {
+        err.json_path
+            .as_ref()
+            .and_then(|path| spec_index.resolve(path))
+            .map(|span| span.line)
+            .or(Some(err.line).filter(|&l| l > 0))
+    })
+}
+
+/// Resolve spec target line from a selected compile error.
+///
+/// Uses the compile error's file path to infer which spec construct it relates
+/// to, then resolves that construct's location in the spec index.
+fn resolve_compile_target(app: &App, spec_index: &SpecIndex) -> Option<usize> {
+    let err = app.selected_compile_error()?;
+    resolve_compile_error_to_spec(err, spec_index)
+}
+
+/// Map a compile error back to its originating spec line.
+///
+/// Strategy: extract the file stem (e.g. "Pet" from `src/models/Pet.java`) and
+/// check if it matches a schema name or API resource in the spec's JSON pointers.
+fn resolve_compile_error_to_spec(err: &CompileError, spec_index: &SpecIndex) -> Option<usize> {
+    let stem = err.file.file_stem()?.to_str()?;
+    let stem_lower = stem.to_ascii_lowercase();
+
+    // Collect pointers once for matching.
+    let pointers = spec_index.pointers();
+
+    // Try exact schema match: "Pet" → /components/schemas/Pet
+    for ptr in &pointers {
+        let parts: Vec<&str> = ptr.split('/').collect();
+        if parts.len() == 4
+            && parts[1] == "components"
+            && parts[2] == "schemas"
+            && (parts[3].to_ascii_lowercase() == stem_lower
+                || stem_lower.starts_with(&parts[3].to_ascii_lowercase())
+                    && is_model_suffix(&stem_lower[parts[3].len()..]))
+        {
+            return spec_index.resolve(ptr).map(|s| s.line);
+        }
+    }
+
+    // Try API path match: "PetsApi" → /paths/~1pets
+    let stem_no_suffix = stem_lower
+        .strip_suffix("api")
+        .or_else(|| stem_lower.strip_suffix("controller"))
+        .or_else(|| stem_lower.strip_suffix("service"))
+        .or_else(|| stem_lower.strip_suffix("handler"))
+        .unwrap_or(&stem_lower);
+
+    for ptr in &pointers {
+        let parts: Vec<&str> = ptr.split('/').collect();
+        if parts.len() >= 3 && parts[1] == "paths" {
+            let path_decoded = parts[2].replace("~1", "/").replace("~0", "~");
+            for segment in path_decoded.split('/') {
+                if !segment.is_empty()
+                    && !segment.starts_with('{')
+                    && segment.to_ascii_lowercase() == *stem_no_suffix
+                {
+                    return spec_index.resolve(ptr).map(|s| s.line);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Check if the remainder after a schema name is a common model suffix.
+fn is_model_suffix(remainder: &str) -> bool {
+    matches!(
+        remainder,
+        "dto" | "model" | "entity" | "response" | "request" | "schema" | "vo" | "bean"
+    )
 }

--- a/src/ui/panels/spec_context.rs
+++ b/src/ui/panels/spec_context.rs
@@ -27,8 +27,8 @@ pub fn draw_spec_context(frame: &mut Frame, app: &App, area: Rect, focused: bool
     };
 
     // Resolve target line: lint errors first, then compile errors.
-    let target_line = resolve_lint_target(app, spec_index)
-        .or_else(|| resolve_compile_target(app, spec_index));
+    let target_line =
+        resolve_lint_target(app, spec_index).or_else(|| resolve_compile_target(app, spec_index));
 
     let radius = (inner.height as usize) / 2;
 

--- a/src/ui/panels/spec_context.rs
+++ b/src/ui/panels/spec_context.rs
@@ -29,15 +29,13 @@ pub fn draw_spec_context(frame: &mut Frame, app: &App, area: Rect, focused: bool
     };
 
     // Resolve the target line from the selected error.
+    // Priority: json_path resolution → raw line number from linter output.
     let target_line = app.selected_error().and_then(|err| {
-        // Try json_path resolution first, fall back to the error's line number.
-        if let Some(ref path) = err.json_path {
-            spec_index.resolve(path).map(|span| span.line)
-        } else if err.line > 0 {
-            Some(err.line)
-        } else {
-            None
-        }
+        err.json_path
+            .as_ref()
+            .and_then(|path| spec_index.resolve(path))
+            .map(|span| span.line)
+            .or(Some(err.line).filter(|&l| l > 0))
     });
 
     let radius = (inner.height as usize) / 2;

--- a/src/ui/panels/spec_context.rs
+++ b/src/ui/panels/spec_context.rs
@@ -1,11 +1,11 @@
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Wrap};
 
 use crate::app::App;
-use crate::ui::style::{COLOR_GUTTER, COLOR_SELECTED_BG, make_block};
+use crate::ui::style::{COLOR_GUTTER, STYLE_HIGHLIGHT_LINE, make_block};
 
 pub fn draw_spec_context(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
     let block = make_block("Spec Context", focused);
@@ -94,7 +94,7 @@ pub fn draw_spec_context(frame: &mut Frame, app: &App, area: Rect, focused: bool
             if let Some(segments) = all_highlighted.get(start_idx + i) {
                 for (style, text) in segments {
                     let style = if is_target {
-                        style.bg(COLOR_SELECTED_BG).add_modifier(Modifier::BOLD)
+                        style.patch(STYLE_HIGHLIGHT_LINE)
                     } else {
                         *style
                     };

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -9,8 +9,20 @@ pub const COLOR_PASS: Color = Color::Green;
 pub const COLOR_FAIL: Color = Color::Red;
 pub const COLOR_RUNNING: Color = Color::Yellow;
 pub const COLOR_PENDING: Color = Color::DarkGray;
-pub const COLOR_SELECTED_BG: Color = Color::DarkGray;
 pub const COLOR_GUTTER: Color = Color::DarkGray;
+
+// ── Selection / highlight styles ──────────────────────────────────────
+// REVERSED adapts to any terminal palette (dark or light) by swapping
+// the foreground and background colours at render time.
+pub const STYLE_SELECTED: Style = Style::new()
+    .add_modifier(Modifier::REVERSED)
+    .add_modifier(Modifier::BOLD);
+
+// For highlighted lines in source viewers (spec context, code browser)
+// underline preserves syntax-highlight colours while marking the line.
+pub const STYLE_HIGHLIGHT_LINE: Style = Style::new()
+    .add_modifier(Modifier::UNDERLINED)
+    .add_modifier(Modifier::BOLD);
 
 // ── Icon constants ────────────────────────────────────────────────────
 pub const ICON_PASS: &str = "✓";


### PR DESCRIPTION
## Summary
- Parse compile errors from generator output and map them back to spec paths via a trace index
- Bidirectional navigation between spec fields and generated code locations
- Compile error jumping with proper clamping and stale-index handling

Closes #27, closes #28